### PR TITLE
Fix for multiline paragraph indentation

### DIFF
--- a/lib/tty/markdown/parser.rb
+++ b/lib/tty/markdown/parser.rb
@@ -79,6 +79,7 @@ module TTY
           symbol = opts[:ordered] ? "#{index}." : bullet
           styles = Array(@theme[:list])
           opts[:result] << @pastel.decorate(symbol, *styles) + ' '
+          opts[:indent] += @indent
           opts[:strip] = true
         when :blockquote
           opts[:indent] = 0

--- a/lib/tty/markdown/parser.rb
+++ b/lib/tty/markdown/parser.rb
@@ -69,6 +69,9 @@ module TTY
           opts[:result] << indent
         end
 
+        opts[:indent] = @current_indent
+        opts[:strip] = false
+
         case opts[:parent].type
         when :li
           bullet = TTY::Markdown.symbols[:bullet]
@@ -76,6 +79,9 @@ module TTY
           symbol = opts[:ordered] ? "#{index}." : bullet
           styles = Array(@theme[:list])
           opts[:result] << @pastel.decorate(symbol, *styles) + ' '
+          opts[:strip] = true
+        when :blockquote
+          opts[:indent] = 0
         end
 
         inner(el, opts)
@@ -127,8 +133,11 @@ module TTY
       end
 
       def convert_text(el, opts)
-        text = el.value
-        opts[:result] << Strings.wrap(text, @width)
+        text = Strings.wrap(el.value, @width)
+        text.strip! if opts[:strip]
+        indent = ' ' * opts[:indent]
+        text = text.gsub(/\n/, "\n#{indent}")
+        opts[:result] <<  text
       end
 
       def convert_strong(el, opts)

--- a/spec/unit/parse/list_spec.rb
+++ b/spec/unit/parse/list_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe TTY::Markdown, 'list' do
     expect(parsed).to eq([
       "    \e[36;1mheader\e[0m",
       "    #{pastel.yellow(symbols[:bullet])} First multiline",
-      "    Item 1",
+      "      Item 1",
       "      #{pastel.yellow(symbols[:bullet])} Second multiline",
-      "      Item 2",
+      "        Item 2",
       "      #{pastel.yellow(symbols[:bullet])} Item 3",
       "    #{pastel.yellow(symbols[:bullet])} Item 4\n",
     ].join("\n"))

--- a/spec/unit/parse/list_spec.rb
+++ b/spec/unit/parse/list_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe TTY::Markdown, 'list' do
       "    #{pastel.yellow(symbols[:bullet])} First multiline",
       "    Item 1",
       "      #{pastel.yellow(symbols[:bullet])} Second multiline",
-      "    Item 2",
+      "      Item 2",
       "      #{pastel.yellow(symbols[:bullet])} Item 3",
       "    #{pastel.yellow(symbols[:bullet])} Item 4\n",
     ].join("\n"))

--- a/spec/unit/parse/list_spec.rb
+++ b/spec/unit/parse/list_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe TTY::Markdown, 'list' do
     ].join("\n"))
   end
 
-  xit "indents unordered list with multiline content" do
+  it "indents unordered list with multiline content" do
     markdown =<<-TEXT
 ### header
 - First multiline

--- a/spec/unit/parse/paragraph_spec.rb
+++ b/spec/unit/parse/paragraph_spec.rb
@@ -17,7 +17,7 @@ And this is a next one.
     ].join("\n"))
   end
 
-  xit "converts multiline pragraphs within header section" do
+  it "converts multiline pragraphs within header section" do
 
     markdown =<<-TEXT
 ### header


### PR DESCRIPTION
Came up with a fix to the multiline paragraph specs that were pending - passing in custom indentation levels when converting text.   

The `opt[:strip]` is added to normalize `li` text.   Nesting list items have a `\n` and non-nesting items do not.

