### PR TITLE
Add converter for br element

### DIFF
--- a/lib/tty/markdown/parser.rb
+++ b/lib/tty/markdown/parser.rb
@@ -402,6 +402,10 @@ module TTY
         end
       end
 
+      def convert_br(el, opts)
+        opts[:result] << "\n"
+      end
+
       def convert_hr(el, opts)
         indent = ' ' * @current_indent
         symbols = TTY::Markdown.symbols


### PR DESCRIPTION
### Describe the change
Adds a converter for `br` elements found in a kramdown document.

### Why are we doing this?
Currently conversion fails with a NoMethodError when a `br` is present.

### Benefits
Eliminates the aforementioned NoMethodError.

### Drawbacks
None

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[] Documentation updated?
