### PR TITLE
Update link handling

### DIFF
--- a/lib/tty/markdown/parser.rb
+++ b/lib/tty/markdown/parser.rb
@@ -417,6 +417,9 @@ module TTY
       def convert_a(el, opts)
         symbols = TTY::Markdown.symbols
         styles = Array(@theme[:link])
+        if URI.parse(el.attr['href']).class == URI::MailTo
+          el.attr['href'] = URI.parse(el.attr['href']).to
+        end
         if el.children.size == 1 && el.children[0].type == :text && el.children[0].value == el.attr['href']
           if !el.attr['title'].nil? && !el.attr['title'].strip.empty?
             opts[:result] << "(#{el.attr['title']}) "

--- a/lib/tty/markdown/parser.rb
+++ b/lib/tty/markdown/parser.rb
@@ -417,17 +417,14 @@ module TTY
       def convert_a(el, opts)
         symbols = TTY::Markdown.symbols
         styles = Array(@theme[:link])
-        if el.children.size == 1 && el.children[0].type == :text
-          opts[:result] << @pastel.decorate(el.attr['href'], *styles)
-        else
+        if el.children.size > 1 || el.children.size == 1 && (el.children[0].type != :text || !el.children[0].value.strip.empty?)
+          inner(el, opts)
           if el.attr['title']
-           opts[:result] << el.attr['title']
+            opts[:result] << " #{symbols[:arrow]}(#{el.attr['title']}) "
           else
-            inner(el, opts)
+            opts[:result] << " #{symbols[:arrow]} "
           end
-          opts[:result] << " #{symbols[:arrow]} "
           opts[:result] << @pastel.decorate(el.attr['href'], *styles)
-          opts[:result] << "\n"
         end
       end
 

--- a/lib/tty/markdown/parser.rb
+++ b/lib/tty/markdown/parser.rb
@@ -417,7 +417,12 @@ module TTY
       def convert_a(el, opts)
         symbols = TTY::Markdown.symbols
         styles = Array(@theme[:link])
-        if el.children.size > 1 || el.children.size == 1 && (el.children[0].type != :text || !el.children[0].value.strip.empty?)
+        if el.children.size == 1 && el.children[0].type == :text && el.children[0].value == el.attr['href']
+          if !el.attr['title'].nil? && !el.attr['title'].strip.empty?
+            opts[:result] << "(#{el.attr['title']}) "
+          end
+          opts[:result] << @pastel.decorate(el.attr['href'], *styles)
+        elsif el.children.size > 1 || el.children.size == 1 && (el.children[0].type != :text || !el.children[0].value.strip.empty?)
           inner(el, opts)
           if el.attr['title']
             opts[:result] << " #{symbols[:arrow]}(#{el.attr['title']}) "

--- a/spec/unit/parse/link_spec.rb
+++ b/spec/unit/parse/link_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe TTY::Markdown, 'link' do
     expect(parsed).to eq("I#{symbols[:rsquo]}m an inline-style link with title #{symbols[:arrow]}(Google's Homepage) \e[33;4mhttps://www.google.com\e[0m\n")
   end
 
+  it "displays email links with mailto: prefix removed" do
+    markdown = "[Email me](mailto:test@example.com)"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("Email me #{symbols[:arrow]} \e[33;4mtest@example.com\e[0m\n")
+  end
+
+  it "displays email links without displaying label when label matches address" do
+    markdown = "[test@example.com](mailto:test@example.com)"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\e[33;4mtest@example.com\e[0m\n")
+  end
+
   it "displays nothing when label is empty" do
     markdown = "[](https://example.com)"
     parsed = TTY::Markdown.parse(markdown)
@@ -47,5 +59,11 @@ RSpec.describe TTY::Markdown, 'link' do
     markdown = "<https://example.com>"
     parsed = TTY::Markdown.parse(markdown)
     expect(parsed).to eq("\e[33;4mhttps://example.com\e[0m\n")
+  end
+
+  it "displays email autolinks without displaying label" do
+    markdown = "<mailto:test@example.com>"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\e[33;4mtest@example.com\e[0m\n")
   end
 end

--- a/spec/unit/parse/link_spec.rb
+++ b/spec/unit/parse/link_spec.rb
@@ -36,4 +36,16 @@ RSpec.describe TTY::Markdown, 'link' do
     parsed = TTY::Markdown.parse(markdown)
     expect(parsed).to eq("\n")
   end
+
+  it "displays link without displaying label when label matches link target" do
+    markdown = "[https://example.com](https://example.com)"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\e[33;4mhttps://example.com\e[0m\n")
+  end
+
+  it "displays typical autolinks without displaying label" do
+    markdown = "<https://example.com>"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\e[33;4mhttps://example.com\e[0m\n")
+  end
 end

--- a/spec/unit/parse/link_spec.rb
+++ b/spec/unit/parse/link_spec.rb
@@ -3,23 +3,37 @@
 RSpec.describe TTY::Markdown, 'link' do
   let(:symbols) { TTY::Markdown.symbols }
 
-  it "converts link" do
+  it "displays link with label" do
     markdown =<<-TEXT
 [I'm an inline-style link](https://www.google.com)
     TEXT
     parsed = TTY::Markdown.parse(markdown)
-    expect(parsed).to eq([
-      "I#{symbols[:rsquo]}m an inline-style link #{symbols[:arrow]} \e[33;4mhttps://www.google.com\e[0m\n"
-    ].join)
+    expect(parsed).to eq("I#{symbols[:rsquo]}m an inline-style link #{symbols[:arrow]} \e[33;4mhttps://www.google.com\e[0m\n")
   end
 
-  it "converts link with title" do
+  it "displays link with label and title" do
     markdown =<<-TEXT
 [I'm an inline-style link with title](https://www.google.com "Google's Homepage")
     TEXT
     parsed = TTY::Markdown.parse(markdown)
-    expect(parsed).to eq([
-      "Google's Homepage #{symbols[:arrow]} \e[33;4mhttps://www.google.com\e[0m\n"
-    ].join)
+    expect(parsed).to eq("I#{symbols[:rsquo]}m an inline-style link with title #{symbols[:arrow]}(Google's Homepage) \e[33;4mhttps://www.google.com\e[0m\n")
+  end
+
+  it "displays nothing when label is empty" do
+    markdown = "[](https://example.com)"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\n")
+  end
+
+  it "displays nothing when label is empty but title is present" do
+    markdown = "[](https://example.com \"Title\")"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\n")
+  end
+
+  it "displays nothing when label is just whitespace" do
+    markdown = "[\n\t ](https://example.com)"
+    parsed = TTY::Markdown.parse(markdown)
+    expect(parsed).to eq("\n")
   end
 end


### PR DESCRIPTION
### Describe the change
Several changes to link conversion are made:
- Simple text link labels are now displayed in many circumstances where they were previously missing (fixes #14)
- When link label is empty or all whitespace the entire link is not displayed
- When a link title is included it is displayed in addition to, rather than instead of, the link label, eg. `[Label](https://example.com "Title")` converts to `Label »(Title) https://example.com`
- When the link label is identical to the link target the label is omitted for brevity, eg. `[https://example.com](https://example.com)` and `<https://example.com>` both simply convert to `https://example.com`
- When the link target is a mailto: URI the mailto: prefix is removed for brevity, eg. `[Email Me](mailto:user@example.com)` converts to `Email Me » user@example.com` and in conjunection with the above change `[user@example.com](mailto:user@example.com)` simply converts to `user@example.com`

### Benefits
In addition to fixing the missing labels described in #14 these changes make the results of link conversions more readable and closer to the output of typical HTML markdown rendering.

### Drawbacks
New behavior might be unexpected for existing users.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[] Documentation updated?
