### PR TITLE
Expand supported rouge versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## unreleased
+
+### Changed
+* Change gemspec to expand supported rouge versions by Ash McKenzie(@ashmckenzie)
+
 ## [v0.7.1] - 2022-12-21
 
 ### Changed

--- a/tty-markdown.gemspec
+++ b/tty-markdown.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "kramdown",   ">= 1.16.2", "< 3.0"
   spec.add_dependency "pastel",     "~> 0.8"
-  spec.add_dependency "rouge",      "~> 3.14"
+  spec.add_dependency "rouge",      ">= 3.14", "< 5.0"
   spec.add_dependency "strings",    "~> 0.2.0"
   spec.add_dependency "tty-color",  "~> 0.5"
   spec.add_dependency "tty-screen", "~> 0.8"


### PR DESCRIPTION
### Describe the change

This PR increases the supported versions of `rouge` to be `">= 3.14", "< 5.0"` as there are [new `4.x` versions of `rouge`](https://github.com/rouge-ruby/rouge/releases).

### Why are we doing this?

The changes allows projects to install this gem as well as versions `4.x` of the `rouge` gem.

### Benefits

Same as above.

### Drawbacks

https://github.com/rouge-ruby/rouge/releases/tag/v4.0.0 dropped support for versions of Ruby < 2.7, so versions 2.7+ are only supported with `rouge` `4.x`.

### Requirements

- [ ] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated? - I haven't updated this as I'm not sure if you want a new minor or patch version.
